### PR TITLE
kwargs passing fix

### DIFF
--- a/app_model.py
+++ b/app_model.py
@@ -509,5 +509,5 @@ class AppModel:
         }
 
         image = self.model.sample_controlnet(src_tokens, gpt_img_src_tokens, img_gpt_input_mask, negative_tokens,
-                                             control_image, self.controlnet, kwargs)
+                                             control_image, self.controlnet, **kwargs)
         return [control_image] + image

--- a/app_model.py
+++ b/app_model.py
@@ -486,7 +486,7 @@ class AppModel:
         }
 
         image = self.model.sample_controlnet(src_tokens, gpt_img_src_tokens, img_gpt_input_mask, negative_tokens,
-                                             control_image, self.controlnet, kwargs)
+                                             control_image, self.controlnet, **kwargs)
         return [control_image] + image
 
     @torch.inference_mode()


### PR DESCRIPTION
The kwargs in instruct pix2pix and content shuffle methods weren't unpacked which caused an error when calling the methods.